### PR TITLE
chore(node): CAP-18848 - update outdated node actions and add pr template

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -13,13 +13,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.20.x
 
       - run: go mod vendor
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.53

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .*.swp
 tests/docker-compose.*.yml
 terraform-provider-postgresql
+.idea/

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# What
+
+### What changes are you introducing?
+
+# Why
+
+### Why are these changes necessary?
+
+### Which issue(s) does this PR address?


### PR DESCRIPTION
# What

- **What changes are you introducing?**
  - Adding a PR template to standardize submissions.
  - Removing dependencies related to node16 to modernize and streamline the development environment.
  - Add CodeQL advanced configuration.

# Why

- **Why are these changes necessary?**
  - The PR template will help ensure consistency and completeness in future pull requests, enhancing the review process.
  - Removing node16 dependencies is crucial as GitHub is sunsetting support for node16 actions. Updating our tech stack to newer versions ensures compatibility with supported tools, improving performance and security.
  - Add CodeQL so that we can adjust configs properly.
- **Which issue(s) does this PR address?**
  - Issue CAP-18848
 
# Test

Before: https://github.com/captivateiq/terraform-provider-postgresql/actions/runs/8753117802
After:
* https://github.com/captivateiq/terraform-provider-postgresql/actions/runs/9006119223
* https://github.com/captivateiq/terraform-provider-postgresql/actions/runs/9006119224
* https://github.com/captivateiq/terraform-provider-postgresql/actions/runs/9006119223